### PR TITLE
다수 이미지 입출력 기능 추가

### DIFF
--- a/MRS3/ServerInterface/Utils.py
+++ b/MRS3/ServerInterface/Utils.py
@@ -14,7 +14,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 import os
 import time
 import struct
-# import 
+import zipfile
 
 def compress_imgpresso(img_path, output_path):
     """
@@ -221,4 +221,28 @@ def unpack_files(input_file: str, output_dir: str):
                 f_out.write(file_data)
 
 
+
+def zip_folder_server(folder_path, zip_filename):
+    """
+    :param folder_path: 폴더 경로
+    :param zip_filename: 저장할 zip 파일명(e.g. compression.zip)
+    """
+    # 지정 폴더 내 모든 파일을 zip 으로 묶어서 저장
+    with zipfile.ZipFile(zip_filename, 'w') as zipf:
+        for filename in os.listdir(folder_path):
+            file_path = os.path.join(folder_path, filename)
+            if os.path.isfile(file_path):  # 파일인지 확인
+                # 압축 내 파일 이름은 파일명만 사용 (전체 경로 아님)
+                zipf.write(file_path, arcname=filename)
+    return
+
+
+def unzip_server(zip_path, extract_folder):
+    """
+    :param zip_path: 압축해제하고자 하는 zip 파일 경로(file.zip)
+    :param extract_folder: 압축해제하여 파일들을 저장할 폴더 경로
+    """
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(extract_folder)  # 모든 파일을 지정한 폴더에 압축 해제
+    return
 


### PR DESCRIPTION
로컬에서 돌아가는지 확인하고 그 코드를 복붙한거라 서버/웹 환경에 맞게 수정이 필요할 수도 있습니다.

**compress_mult_img_server:** 
> 입력경로 폴더 내 모든 이미지를 한 번에 pkg 변환하여 지정한 폴더에 저장하는 함수입니다. manual=True 면 수동타겟설정, False면 자동타겟설정 입니다. 자동타겟설정의 경우, 지금은 얼굴만 인식하도록 해놨는데, 차후 몸전체, 동물, 사물도 옵션으로 인식가능토록 하면 좋을 듯 합니다.

> 위 작업이 끝난 후에 Utils 에 정의해놓은 zip_folder_server 활용해서 사용자에게 리턴하면 될듯 합니다.

> 제가 TODO 라고 해놓은 부분이 있는데, 여기에는 iteration 에 해당하는 이미지에 대해 프론트엔드에서 수동으로 좌표찍은 roi_point_lists 를 가져오도록 해주시면 감사하겠습니다

> imgpresso 기능과 중첩이 가능하게 하려면 약간 수정이 필요할 것 같습니다. 이 부분은 이어서 작업해볼게요.

**restore_imgs_in_folder_server:**
> 지정한 폴더(pkg 가 모여있는 폴더) 내 모든 pkg 를 png 로 복원합니다.

> 사용자가 업로드한 파일이 zip 이면 Utils 에 정의한 unzip_server 활용해서 압축풀고 해당 경로를 입력하면 될 거 같네요

**_upscale_by_edsr:**
> 코드 테스트하실 때 edsr 도 확인할 수 있도록 cpu 에서도 돌아가도록 설정해놨습니다.

**yolov8face**
> 얼굴인식은 이렇게 나오고 사각형으로 잘라서 자동으로 pkg 저장되게 만들었습니다.

<img width="2560" height="1600" alt="Screenshot from 2025-07-30 16-43-01" src="https://github.com/user-attachments/assets/30cf5f47-2130-4381-84a9-3546243f6666" />

> 아래 사진은 unpack 해서 확인해본 결과입니다
<img width="197" height="400" alt="Screenshot from 2025-07-30 16-44-26" src="https://github.com/user-attachments/assets/c7a18a54-8dd0-4224-9b4e-be74fbfb6370" />

**자동압축 및 복원 결과:**
> 얼굴만 타겟팅하면 압축 시 대략 기존용량의 20-40퍼센트 정도가 되는거 같네요.
<img width="1168" height="451" alt="image" src="https://github.com/user-attachments/assets/cb37c4dc-6bed-4eeb-b20a-ca4ad05336fa" />

> 원본 이미지
<img width="1920" height="1080" alt="1920x1080" src="https://github.com/user-attachments/assets/48f1613b-0f82-46b8-9651-1383ae2f9895" />

> 복원 이미지
<img width="1920" height="1080" alt="1920x1080" src="https://github.com/user-attachments/assets/b8fc6cd5-3a48-4d37-b74c-b088462b2255" />

> 얼굴 부분은 그대로 보존되고 옷 부분에서 약간 텍스쳐가 달라보이네요. 용량은 기존의 36퍼센트입니다. EDSR 외에 다른 SR 은 어떻게 될지 적용해보겠습니다.